### PR TITLE
Don't reconstruct the default linkifier on every prop update.

### DIFF
--- a/src/Hyperlink.js
+++ b/src/Hyperlink.js
@@ -15,16 +15,14 @@ import mdurl from 'mdurl';
 const textPropTypes = Text.propTypes || {}
 const { OS } = Platform
 
+const DEFAULT_LINKIFY = require('linkify-it')();
+
 class Hyperlink extends Component {
   constructor(props){
     super(props)
     this.linkify = this.linkify.bind(this)
     this.parse = this.parse.bind(this)
-    this.linkifyIt = props.linkify || require('linkify-it')()
-  }
-
-  componentWillReceiveProps ({ linkify = require('linkify-it')() } = {}) {
-    this.linkifyIt = linkify
+    this.linkifyIt = props.linkify || DEFAULT_LINKIFY;
   }
 
   render() {


### PR DESCRIPTION
Instead, use a single default linkifier. This also removes the ability
to update the linkifier in componentWillReceiveProps; we don't care
about being able to do that.

This is worth doing because reconstructing the linkifier involves
doing a surprising amount of work, including compiling a
3000-character regular expression.